### PR TITLE
Update usage to YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,10 @@ GitHub Actions for [Composer](https://getcomposer.org). Base on Docker official 
 
 Via GitHub Workflow
 
-```
-action "Composer Install" {
-  uses = "MilesChou/composer-action@master"
-  args = "install"
-}
+```yaml
+- uses: MilesChou/composer-action@master
+  with:
+    args: install
 ```
 
 ## Credits


### PR DESCRIPTION
Updated the readme since [HCL is no longer supported](https://help.github.com/en/github/automating-your-workflow-with-github-actions/about-github-actions#migrating-github-actions-from-hcl-to-yaml-syntax)